### PR TITLE
add pcall on for vim.version.parse

### DIFF
--- a/lua/neocodeium/utils/init.lua
+++ b/lua/neocodeium/utils/init.lua
@@ -109,8 +109,8 @@ end
 ---Returns neovim version
 ---@return string
 function M.get_neovim_version()
-  local obj = vim.version.parse(M.exec("version"))
-  if obj then
+  local ok, obj = pcall(vim.version.parse, M.exec("version"))
+  if ok and obj then
     return string.format("%d.%d.%d", obj.major, obj.minor, obj.patch)
   else
     return "unknown"


### PR DESCRIPTION
Hello! Thanks for the cool plugin. When I open neovim and immediately go into command mode, sometimes the following error appears:
```
Failed to run `config` for neocodeium
/usr/share/nvim/runtime/lua/vim/version.lua:177: attempt to index local 'version' (a nil value)
# stacktrace:
  - /usr/share/nvim/runtime/lua/vim/version.lua:177 _in_ **parse**
  - /neocodeium/lua/neocodeium/utils/init.lua:112 _in_ **get_neovim_version**
  - /neocodeium/lua/neocodeium/server.lua:238
  - /neocodeium/lua/neocodeium/commands.lua:10
  - /neocodeium/lua/neocodeium/init.lua:147 _in_ **setup**
  - ~/.config/nvim/lua/plugins/coding.lua:252 _in_ **config**

```

I thought that I could wrap the parsing version in a pcall

P.s.There is another problem not related to this P.R.
When I use `neocodeium.accept` for Cyrillic, some characters are missed, so the word is misspelled. (For example, `hllo` instead of `hello`). But this is more complicated than just a `pcall`))