### PR TITLE
Fix buffer enable/disable logic in commands.lua

### DIFF
--- a/lua/neocodeium/commands.lua
+++ b/lua/neocodeium/commands.lua
@@ -155,11 +155,11 @@ function M.enable()
 end
 
 function M.disable_buffer()
-  vim.b.neocodeium_enabled = false
+  vim.b.neocodeium_disabled = true
 end
 
 function M.enable_buffer()
-  vim.b.neocodeium_enabled = true
+  vim.b.neocodeium_disabled = false
 end
 
 function M.open_log()


### PR DESCRIPTION
- Changed the buffer disabling logic to set neocodeium_disabled to true as it is used in completer. Otherwise neocodeium_enabled was never used.
