### PR TITLE
fix: Syntax error in nvim-cmp setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ place where nvim-cmp is configured:
     neocodeium.setup({
         enabled = function()
             return not cmp.visible()
-        end),
+        end,
     })
 
     cmp.setup({


### PR DESCRIPTION
Got a syntax error when copying the setup for nvim-cmp. Removed the culprit parentheses