### PR TITLE
Add user events for useful events for optimizing statusline performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,20 @@ NeoCodeium provides `:NeoCodeium` user command, which has some useful actions:
 You can also use such commands in your lua scripts by calling
 `require("neocodeium.commands").<command_name>()`.
 
+#### 📆 User Events
+
+NeoCodeium triggers several user events which can be used to trigger code. These can be used to optimize when statusline elements are updated, creating mappings only when the server is available, or modifying completion engine settings when AI completion is started or displaying hints.
+
+- `NeoCodeiumServerConnecting` - triggers when a connection to the Codeium server is starting
+- `NeoCodeiumServerConnected` - triggers when a successful connection to the Codeium server is made
+- `NeoCodeiumServerStopped` - triggers when the Codeium server is stopped
+- `NeoCodeiumEnabled` - triggers when the NeoCodeium plugin is enabled globally
+- `NeoCodeiumDisabled` - triggers when the NeoCodeium plugin is disabled globally
+- `NeoCodeiumBufEnabled` - triggers when the NeoCodeium plugin is enabled for a buffer
+- `NeoCodeiumBufDisabled` - triggers when the NeoCodeium plugin is disabled for a buffer
+- `NeoCodeiumCompletionDisplayed` - triggers when NeoCodeium successfully displays a completion item as virtual text
+- `NeoCodeiumCompletionCleared` - triggers when NeoCodeium clears virtual text and completions
+
 #### 🚃 Statusline
 
 `require("neocodeium").get_status()` can be used to get the some useful information about the current state.

--- a/lua/neocodeium/commands.lua
+++ b/lua/neocodeium/commands.lua
@@ -181,9 +181,10 @@ function M.restart()
 end
 
 function M.toggle()
-   vim.g.neocodeium_enabled = vim.g.neocodeium_enabled == false
-   if vim.g.neocodeium_enabled and not server.pid then
-      server:run()
+   if vim.g.neocodeium_enabled == false then
+      M.enable()
+   else
+      M.disable()
    end
 end
 

--- a/lua/neocodeium/commands.lua
+++ b/lua/neocodeium/commands.lua
@@ -146,10 +146,12 @@ end
 
 function M.disable()
    vim.g.neocodeium_enabled = false
+   utils.event("Disabled")
 end
 
 function M.enable()
    vim.g.neocodeium_enabled = true
+   utils.event("Enabled")
    if not server.pid then
       server:run()
    end
@@ -157,10 +159,12 @@ end
 
 function M.disable_buffer()
    vim.b.neocodeium_enabled = false
+   utils.event("BufDisabled")
 end
 
 function M.enable_buffer()
    vim.b.neocodeium_enabled = true
+   utils.event("BufEnabled")
 end
 
 function M.open_log()

--- a/lua/neocodeium/renderer.lua
+++ b/lua/neocodeium/renderer.lua
@@ -279,7 +279,7 @@ function Renderer:display(items, index)
    if block_text or #inline_contents > 0 then
       self:display_label(items, index)
    end
-   utils.event("CompletionDisplayed")
+   utils.event("CompletionDisplayed", true)
    return true
 end
 
@@ -441,7 +441,7 @@ function Renderer:reset()
    self.block.id = nil
    self.block.text = nil
    self.fulltext = ""
-   utils.event("CompletionCleared")
+   utils.event("CompletionCleared", true)
 end
 -- }}}1
 

--- a/lua/neocodeium/renderer.lua
+++ b/lua/neocodeium/renderer.lua
@@ -279,6 +279,7 @@ function Renderer:display(items, index)
    if block_text or #inline_contents > 0 then
       self:display_label(items, index)
    end
+   utils.event("CompletionDisplayed")
    return true
 end
 
@@ -440,6 +441,7 @@ function Renderer:reset()
    self.block.id = nil
    self.block.text = nil
    self.fulltext = ""
+   utils.event("CompletionCleared")
 end
 -- }}}1
 

--- a/lua/neocodeium/server.lua
+++ b/lua/neocodeium/server.lua
@@ -3,6 +3,7 @@
 local log = require("neocodeium.log")
 local api_key = require("neocodeium.api_key")
 local options = require("neocodeium.options").options
+local utils = require("neocodeium.utils")
 local stdio = require("neocodeium.utils.stdio")
 local echo = require("neocodeium.utils.echo")
 local Bin = require("neocodeium.binary")
@@ -97,6 +98,7 @@ function Server:start()
             self.handle = nil
          end
          log.info("Server stopped")
+         utils.event("ServerStopped")
          self.pid = nil
          self.port = nil
          if self.is_restart then
@@ -105,7 +107,7 @@ function Server:start()
          end
       end)
    )
-
+   utils.event("ServerConnecting")
    local function log_data(err, data)
       if err then
          return
@@ -239,6 +241,7 @@ function Server:init(timer, manager_dir)
          self.callback()
          self.callback = nil
       end
+      utils.event("ServerConnected")
 
       timer:stop()
       local interval = 10000

--- a/lua/neocodeium/utils/init.lua
+++ b/lua/neocodeium/utils/init.lua
@@ -21,8 +21,16 @@ end
 
 --- Trigger a NeoCodeium event
 ---@param event string The event pattern
-function M.event(event)
-   vim.api.nvim_exec_autocmds("User", { pattern = "NeoCodeium" .. event, modeline = false })
+---@param scheduled boolean? Whether or not to schedule the event
+function M.event(event, scheduled)
+   local event_opts = { pattern = "NeoCodeium" .. event, modeline = false }
+   if scheduled then
+      vim.schedule(function()
+         vim.api.nvim_exec_autocmds("User", event_opts)
+      end)
+   else
+      vim.api.nvim_exec_autocmds("User", event_opts)
+   end
 end
 
 ---Returns cursor position in the current window

--- a/lua/neocodeium/utils/init.lua
+++ b/lua/neocodeium/utils/init.lua
@@ -19,6 +19,12 @@ function M.exec(cmd)
    return result.output
 end
 
+--- Trigger a NeoCodeium event
+---@param event string The event pattern
+function M.event(event)
+   vim.api.nvim_exec_autocmds("User", { pattern = "NeoCodeium" .. event, modeline = false })
+end
+
 ---Returns cursor position in the current window
 ---Unlike `vim.api.nvim_win_get_cursor()`, it returns 0-based indexes
 ---@return pos


### PR DESCRIPTION
When adding status to the statusline many statusline providers support caching and updating on events. This adds some helpful user events which can be used to optimize the use of `get_status` so that it's not calling `get_status` on every clock tick. I also went ahead and added a useful section to the README to help expose this feature to the user. This also provides a means for the user to create mappings only when the codeium server is connected and then removing them when the codeium server disconnects.


Thanks so much for a great plugin it works marvelously!

EDIT: This also adds a `toggle_buffer` command as that seems pretty useful as well 😄 

Closes #21 