### PR TITLE
Recommendation for clearing up buffer local and global enabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cmp.event:on("menu_opened", function()
 end)
 
 neocodeium.setup({
-    enabled = function()
+    filter = function()
         return not cmp.visible()
     end,
 })
@@ -173,13 +173,13 @@ require("neocodeium").setup({
 ```lua
 local filetypes = { 'lua', 'python' }
 neocodeium.setup({
--- function accepts one argument `bufnr`
-enabled = function(bufnr)
-    if vim.tbl_contains(filetypes, vim.api.nvim_get_option_value('filetype', { buf = bufnr })) then
+  -- function accepts one argument `bufnr`
+  filter = function(bufnr)
+    if vim.tbl_contains(filetypes, vim.api.nvim_get_option_value('filetype',  { buf = bufnr})) then
         return true
     end
     return false
-end
+  end
 })
 ```
 </details>
@@ -406,6 +406,9 @@ require("neocodeium").setup({
   max_lines = 10000,
   -- Set to `true` to disable some non-important messages, like "NeoCodeium: server started..."
   silent = false,
+  -- Set to a function that returns `true` if a buffer should be enabled
+  -- and `false` if the buffer should be disabled
+  filter = function(bufnr) return true end,
   -- Set to `false` to disable suggestions in buffers with specific filetypes
   filetypes = {
     help = false,

--- a/lua/neocodeium/commands.lua
+++ b/lua/neocodeium/commands.lua
@@ -170,10 +170,13 @@ end
 function M.enable_buffer()
    vim.b.neocodeium_enabled = true
    utils.event("BufEnabled")
+   if not server.pid then
+      server:run()
+   end
 end
 
 function M.toggle_buffer()
-   if vim.b.neocodeium_enabled == false then
+   if vim.F.if_nil(vim.b.neocodeium_enabled, vim.g.neocodeium_enabled) == false then
       M.enable_buffer()
    else
       M.disable_buffer()


### PR DESCRIPTION
This is a recommendation for restructuring the `vim.b.neocodeium_enabled` and `vim.g.neocodeium_enabled` variables to allow not only disabling individual buffers but also enabling individual buffers.

This also also recommends separating out the function for filtering buffers after being enabled to make it clearer what it's used for, similar to the `filetypes` setting.

This is a relatively large change and is meant to be a recommendation that aligns with how buffer/window local options in core vim such as comment string, completion opts, indentation, etc.

Resolves #27