### PR TITLE
Separate out filter function from enabled setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cmp.event:on("menu_opened", function()
 end)
 
 neocodeium.setup({
-    enabled = function()
+    filter = function()
         return not cmp.visible()
     end,
 })
@@ -173,13 +173,13 @@ require("neocodeium").setup({
 ```lua
 local filetypes = { 'lua', 'python' }
 neocodeium.setup({
--- function accepts one argument `bufnr`
-enabled = function(bufnr)
-    if vim.tbl_contains(filetypes, vim.api.nvim_get_option_value('filetype', { buf = bufnr })) then
+  -- function accepts one argument `bufnr`
+  filter = function(bufnr)
+    if vim.tbl_contains(filetypes, vim.api.nvim_get_option_value('filetype',  { buf = bufnr})) then
         return true
     end
     return false
-end
+  end
 })
 ```
 </details>
@@ -406,6 +406,9 @@ require("neocodeium").setup({
   max_lines = 10000,
   -- Set to `true` to disable some non-important messages, like "NeoCodeium: server started..."
   silent = false,
+  -- Set to a function that returns `true` if a buffer should be enabled
+  -- and `false` if the buffer should be disabled
+  filter = function(bufnr) return true end,
   -- Set to `false` to disable suggestions in buffers with specific filetypes
   filetypes = {
     help = false,

--- a/lua/neocodeium/options.lua
+++ b/lua/neocodeium/options.lua
@@ -2,7 +2,7 @@ local nvim_buf_get_var = vim.api.nvim_buf_get_var
 local nvim_get_option_value = vim.api.nvim_get_option_value
 
 ---@class Options
----@field enabled function|boolean
+---@field enabled boolean
 ---@field bin? string
 ---@field manual boolean
 ---@field server { api_url?: string, portal_url?: string }
@@ -12,6 +12,7 @@ local nvim_get_option_value = vim.api.nvim_get_option_value
 ---@field silent boolean
 ---@field filetypes table<string, boolean>
 ---@field root_dir string[]
+---@field filter fun(bufnr: integer)?
 ---@field enabled_func function
 local defaults = {
    enabled = true,
@@ -37,9 +38,15 @@ function M.setup(opts)
    ---@type Options
    M.options = vim.tbl_deep_extend("force", defaults, opts or {})
 
-   if type(M.options.enabled) == "boolean" then
-      vim.g.neocodeium_enabled = M.options.enabled
+   if type(M.options.enabled) == "function" then
+      M.options.filter = M.options.enabled
+      M.options.enabled = true
+      vim.notify(
+         "Using a function for `enabled` is deprecated, please use the `filter` option instead",
+         vim.log.levels.WARN
+      )
    end
+   vim.g.neocodeium_enabled = M.options.enabled
 
    ---@param bufnr? bufnr
    ---@return boolean, integer
@@ -56,8 +63,8 @@ function M.setup(opts)
          return false, 2 -- locally disabled for current buffer
       end
 
-      if type(M.options.enabled) == "function" then
-         local result = M.options.enabled(bufnr)
+      if M.options.filter then
+         local result = M.options.filter(bufnr)
          if result then
             return result, 0 -- enabled
          else


### PR DESCRIPTION
As discussed in #28 this separates out the filter function from the enabled setting. The main goal of this is to (1) make it clear that the enabling setting is separate from the function itself and (2) allow for disabling neocodeium on startup while also having a function for filtering buffers when it is enabled