### PR TITLE
This allows this plugin to work with codeium enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ a different plugin manager, please refer to its documentation for installation i
 
 Now you can use `Alt-f` in insert mode to accept codeium suggestions.
 
+Enterprise users: you should receive portal and API URLs for Codeium from your company.
+Once you get them, add them to your config. This way `:NeoCodeium auth` will authenticate you on the right portal. For example,
+
+````lua
+{
+  "monkoose/neocodeium",
+  event = "VeryLazy",
+  opts = {
+    server = {
+      api_url = 'https://codeium.company.net/_route/api_server',
+      portal_url = 'https://codeium.company.net',
+    },
+  }
+}
+
 **Note:** To obtain an API token, you’ll need to run `:NeoCodeium auth`.
 On Windows WSL `wslview` `(sudo apt install wslu)` should be installed to properly open the browser.
 

--- a/lua/neocodeium/binary.lua
+++ b/lua/neocodeium/binary.lua
@@ -93,7 +93,7 @@ function Bin:download(callback)
    )
 end
 
----Expands langauge server binary from compressed file.
+---Expands language server binary from compressed file.
 ---Returns `true` on success and `false` on failure.
 ---@return boolean
 function Bin:expand()

--- a/lua/neocodeium/binary.lua
+++ b/lua/neocodeium/binary.lua
@@ -66,9 +66,6 @@ end
 ---@param callback fun()
 function Bin:download(callback)
    local base_url = "https://github.com/Exafunction/codeium/releases/download"
-   if options.server.portal_url then
-      base_url = options.server.portal_url:gsub("/$", "")
-   end
    ---@type url
    local url = string.format(
       "%s/language-server-v%s/language_server_%s.gz",

--- a/lua/neocodeium/server.lua
+++ b/lua/neocodeium/server.lua
@@ -69,10 +69,19 @@ function Server:start()
 
    local args = {
       "--api_server_url",
-      api_url and api_url .. " --enterprise_mode" or "https://server.codeium.com",
+      api_url or "https://server.codeium.com",
       "--manager_dir",
       manager_dir,
    }
+
+   if options.server.api_url and options.server.api_url ~= "" then
+      table.insert(args, "--enterprise_mode")
+   end
+
+   if options.server.portal_url and options.server.portal_url ~= "" then
+      table.insert(args, "--portal_url")
+      table.insert(args, options.server.portal_url)
+   end
 
    if self.chat_enabled then
       table.insert(args, "--enable_local_search")


### PR DESCRIPTION
While looking at #35, I realized that the even if the language server binary was downloaded and extracted correctly, this was not going to work.

The problem was that the final url to the API was not formatted correctly.

To handle the binary situation, I added a check, if it fails then the binary is downloaded from GitHub.

Both these issues have been fixed here.

Tested both with and without codeium enterprise. As far as I can tell all functionality remains the same.

Ouput of `:checkhealth neocodeium`:
```output

==============================================================================
neocodeium: require("neocodeium.health").check()

System information: ~
- *linux* *(x64)*
  If it is not correctly detected, then consider to report a bug at
  https://github.com/monkoose/neocodeium/issues

Checks: ~
- OK *curl* is installed
- OK *API* *key* is present
- OK *Server* *binary* exists: ~/.codeium/bin/1.14.12/language_server_linux_x64
- OK *Server* is running on port 43177 with pid 1685253

```

Commits:

- **fix(server): pass enterprise args correctly to language server**
- **fix(binary): typo**
- **fix(binary): fixes #35**
