### PR TITLE
Refactor LazyVim example to follow idiomatic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,17 @@ a different plugin manager, please refer to its documentation for installation i
 {
   "monkoose/neocodeium",
   event = "VeryLazy",
-  config = function()
-    local neocodeium = require("neocodeium")
-    neocodeium.setup()
-    vim.keymap.set("i", "<A-f>", neocodeium.accept)
-  end,
+  keys = {
+    {
+      "<A-f>",
+      function()
+        require("neocodeium").accept()
+      end,
+      mode = { "i" },
+      desc = "Accept suggestion",
+    },
+  },
+  opts = {},
 }
 
 ```


### PR DESCRIPTION
According to the [Lazy.nvim plugin specification](https://lazy.folke.io/spec):

1. Setting the opts field implicitly defines Plugin.config(), which results in require("neocodium").setup(opts).
2. Using opts is the recommended way to configure plugins.
3. Lazy.nvim also provides the keys field for defining key mappings.

Therefore, I propose this small change to ensure consistent and idiomatic Lazy.nvim usage.