### PR TITLE
Fix autocomplete delay

### DIFF
--- a/lua/neocodeium/init.lua
+++ b/lua/neocodeium/init.lua
@@ -219,7 +219,14 @@ local function enable_autocmds()
 
    create_autocmd("CursorMovedI", {
       callback = function()
-         completer:initiate()
+         local pos = utils.get_cursor()
+         if
+            pos[1] ~= state.pos[1]
+            or pos[2] ~= state.pos[2]
+            or api.nvim_get_current_line() ~= state.curline_text
+         then
+            completer:initiate()
+         end
          if fn.pumvisible() == 0 then
             selected_compl = default_selected_compl
          end

--- a/lua/neocodeium/init.lua
+++ b/lua/neocodeium/init.lua
@@ -191,7 +191,14 @@ local function enable_autocmds()
       callback = function()
          local cur_selected = fn.complete_info({ "selected" }).selected
          if selected_compl == cur_selected then
-            completer:initiate()
+            local pos = utils.get_cursor()
+            if
+               pos[1] ~= state.pos[1]
+               or pos[2] ~= state.pos[2]
+               or api.nvim_get_current_line() ~= state.curline_text
+            then
+               completer:initiate()
+            end
          else
             selected_compl = cur_selected
             completer:clear(true)


### PR DESCRIPTION
The flickering was happening because the native popup appearing after autocompletedelay fires spurious CursorMovedI and TextChangedP events. Neocodeium catches these, notices changedtick hasn't changed, and clears the ghost text thinking the user moved the cursor with arrow keys.

To avoid this, these commits add guards to both CursorMovedI and TextChangedP. By verifying if the cursor position or line text actually changed, we ignore Neovim's spurious events and prevent the plugin from needlessly clearing the virtual text and causing the jitter.